### PR TITLE
Enforce review before trigger release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
 
   release:
     name: Release
+    environment: prod
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     needs: draft_release


### PR DESCRIPTION
# Description
To enforce review before release, `release` job use `prod` environment.
Before create this pull-request, I prepared  `prod` environment and set `Required reviewers` option to true.

### Contributor License Agreements
- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
