### PR TITLE
Reduce renovate update frequency only @types/node

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,15 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>Kesin11/renovate-config:oss",
     "schedule:weekends"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["@types/node"],
+      "extends": [
+        "schedule:monthly"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
# Description

Reduce renovate update schedule only `@types/node`. `@types/node` updates almost every weekend, but it only affects development (it's devDependency), so we don't need latest version every weekend.
I tested the same configuration with my [other repository](https://github.com/Kesin11/ts-junit2json) and it seems to work well.


### Related issue:
ref: https://github.com/DeNA/setup-job-workspace-action/pull/82#issuecomment-1565831853

> [Recent pull-requests](https://github.com/DeNA/setup-job-workspace-action/pulls?q=is%3Apr+is%3Aclosed) are created by Renovate and these are most about @types/node, so I'll change renovate config to reduce frequency.

### Contributor License Agreements
- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
