### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ jobs:
       # Must use before actions/checkout
       - uses: DeNA/setup-job-workspace-action@v2
       - uses: actions/checkout@v3
+        with:
+          clean: false # keep your Unity Library folder to be reussable
 
       # ... your build steps
 
@@ -24,6 +26,8 @@ jobs:
           # You can change workspace name from default: ${workflow-yaml-name}-${job-name}
           workspace-name: foo_bar_workspace
       - uses: actions/checkout@v3
+        with:
+          clean: false # keep your Unity Library folder to be reussable
 
       # ... your build steps
 
@@ -45,6 +49,8 @@ jobs:
         with:
           workspace-name: ${{ steps.set-workspace-name.outputs.result }}
       - uses: actions/checkout@v3
+        with:
+          clean: false # keep your Unity Library folder to be reussable
 
       # ... your build steps
 
@@ -58,6 +64,8 @@ jobs:
           prefix: "prefix-"
           suffix: "-suffix"
       - uses: actions/checkout@v3
+        with:
+          clean: false # keep your Unity Library folder to be reussable
 
       # ... your build steps
 ```


### PR DESCRIPTION
# Description
Improvement.

This PR explicitly guide user to use `action/checkout` with `clean: false` option.

## Background

Please correct me if my understand is wrong. `DeNA/setup-job-workspace-action` is to achieve Jenkins checkout strategy "keeps .git for each node & job" on GitHub Actions by "keep .git for each runner & workspace". Therefore `actions/checkout` still expected to be used with `clean: false` option to avoid `git clean -ffdx`. 

Current README.md not indicate `actions/checkout` to use with `clean: false`, however it may reduce confusion to explicitly show example.

### Related issue:

### Contributor License Agreements
- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
