### PR TITLE
update to node20

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-16",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 16.x
+      - name: Set Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set Node.js 16.x
+      - name: Set Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,6 @@ inputs:
     description: 'Set working-directory for nodejs. default: "" (Linux, macOS), ".." (Windows)'
     default: "${{ runner.os == 'Windows' && '..' || '' }}"
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/main/index.js'
   post: 'dist/post/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=v16.20.2"
+        "node": ">=20"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A action create workspace to checkout repository for each jobs",
   "main": "lib/main.js",
   "engines": {
-    "node": ">=v16.20.2"
+    "node": ">=20"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
# Description

update to node20 action.

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: 
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

### Related issue:

### Contributor License Agreements
- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
