### PR TITLE
Add ignore rules for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "actions/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       actions-minor:
         update-types:


### PR DESCRIPTION
This pull request introduces a configuration change to Dependabot to reduce noise from minor and patch updates to GitHub Actions.

Dependabot configuration:

* Updated `.github/dependabot.yml` to ignore all minor and patch updates for dependencies matching `actions/*`, preventing unnecessary pull requests for these updates.