### PR TITLE
update LICENSE

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) DeNA Co.,Ltd.
+Copyright (c) 2018 GitHub, Inc. and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the project's licensing information to clarify copyright ownership and ensure proper attribution.

**Licensing updates:**

* Updated the copyright holder in the `LICENSE` file from "GitHub, Inc. and contributors" to "DeNA Co.,Ltd."
* Added a new `COPYING` file containing the full MIT license text with attribution to "GitHub, Inc. and contributors."