### PR TITLE
Update .gitattributes with export-ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,13 @@
-dist/** -diff linguist-generated=true 
+dist/** -diff linguist-generated=true
+
+# export settings
+src/** export-ignore
+.husky/** export-ignore
+.github/** export-ignore
+*.json export-ignore
+*.md export-ignore
+.* export-ignore
+*.yaml export-ignore
+*.mjs export-ignore
+*.ts export-ignore
+*.config.js export-ignore


### PR DESCRIPTION
Add export-ignore settings for various file types and directories.

# Description

This pull request updates the `.gitattributes` file to improve export settings by specifying which files and directories should be ignored during package exports.

Export settings improvements:

* Added `export-ignore` rules for the `src/`, `.husky/`, `.github/` directories, various file types (e.g., `.json`, `.md`, `.yaml`, `.mjs`, `.ts`), and configuration files to exclude them from package exports.

### Related issue:

### Contributor License Agreements

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
